### PR TITLE
Bump version bound on base (GHC 8/base-4.9)

### DIFF
--- a/bindings-levmar.cabal
+++ b/bindings-levmar.cabal
@@ -77,7 +77,7 @@ source-repository head
   location: git://github.com/basvandijk/bindings-levmar.git
 
 library
-  build-depends: base         >= 3      && < 4.9
+  build-depends: base         >= 3      && < 4.10
                , bindings-DSL >= 1.0.15 && < 1.1
   exposed-modules: Bindings.LevMar
   ghc-options: -Wall


### PR DESCRIPTION
Bump the upper version bound on base to make bindings-levmar compatible with GHC 8/base-4.9.
